### PR TITLE
Allow setting keyboard brightness on MacbookPro11,4.

### DIFF
--- a/src/asmctl.c
+++ b/src/asmctl.c
@@ -490,12 +490,12 @@ int main(int argc, char *argv[])
 	/* initialize */
 	if (get_ac_powered()<0) return 1;
 	if (get_video_level()<0) return 1;
-	if (get_video_levels()<0) return 1;
 
 	if (argc>2) {
 		if (strcmp(argv[1],"video")==0||
 		    strcmp(argv[1],"lcd")==0)
 		{
+			if (get_video_levels()<0) return 1;
 			if (strcmp(argv[2],"up")==0||
 			    strcmp(argv[2],"u")==0)
 			{


### PR DESCRIPTION
Some systems such as the MacbookPro11,4 allow setting of the keyboard backlight using dev.asmc.0.light.control, but not the monitor backlight. asmc would bork early when attempting to set the keyboard backlight, because the lcd backlight values were unavailable.

Example of previous behavior:

```
$ /usr/local/bin/asmctl key up
sysctl hw.acpi.video.lcd0.levels : Operation not supported by device
# sysctl dev.asmc.0.light.control=100
dev.asmc.0.light.control: 0 -> 100
```