### PR TITLE
Add backlight(9) support, add `asmctl key acpi`, correctly set default fullpower/economy levels, sort levels, cleanup formatting, cleanup memory, fix capability bug

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 BSD 2-Clause License
 
 Copyright (c) 2015, Yuichiro NAITO (naito.yuichiro@gmail.com)
+Copyright (c) 2024, Joshua Rogers (joshua@joshua.hu)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ One is for ac powered and the other is for battery powered.
 Asmctl adjusts these two values relies on acpi ac power status.
 
 ```/usr/local/etc/devd/asmctl.conf``` makes FreeBSD devd
-triggering ```asmctl video acpi```.
+triggering ```asmctl video acpi``` and ```asmctl key acpi```.
 
 ## SECURITY
 

--- a/devd/asmctl.conf.s
+++ b/devd/asmctl.conf.s
@@ -3,4 +3,5 @@ notify 20 {
 	match "subsystem"	"ACAD";
 	action "/etc/rc.d/power_profile $notify";
 	action "%%BINDIR%%/asmctl video acpi";
+	action "%%BINDIR%%/asmctl key acpi";
 };

--- a/src/asmctl.c
+++ b/src/asmctl.c
@@ -39,6 +39,7 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <sys/ioctl.h>
+#include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/asmctl.c
+++ b/src/asmctl.c
@@ -536,8 +536,6 @@ int get_backlight_video_levels() {
 	if (props.nlevels != 0) {
 		num_of_video_levels = props.nlevels; // XXX: +1 for level=0?
 	} else {
-		/* XXX: some screens may not allow intervals of 1, allow
-		 * intervals of 2 (and 0) */
 		num_of_video_levels = BACKLIGHTMAXLEVELS + 1; // 0-100 inclusive
 	}
 

--- a/src/asmctl.c
+++ b/src/asmctl.c
@@ -1,5 +1,6 @@
 /*-
  * Copyright (c) 2015 Yuichiro NAITO <naito.yuichiro@gmail.com>
+ * Copyright (c) 2024 Joshua Rogers <joshua@joshua.hu>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/asmctl.c
+++ b/src/asmctl.c
@@ -30,9 +30,9 @@
  *
  * This command may require the following sysctl variables:
  *
- *  hw.acpi.video.lcd0.*    (acpi_video(4))
- *  hw.asmc.0.light.control (asmc(4))
- *  hw.acpi.acline	  (acpi(4))
+ *  hw.acpi.video.lcd0.*	(acpi_video(4))
+ *  hw.asmc.0.light.control	(asmc(4))
+ *  hw.acpi.acline		(acpi(4))
  *
  */
 
@@ -89,31 +89,31 @@ int num_of_video_levels = 0;
 /* Array of video level values (either backlight(9) or acpi_video) */
 int *video_levels = NULL;
 
-/* hw.acpi.video backlight current level (one of video_levels)*/
+/* hw.acpi.video backlight current level (one of video_levels) */
 int acpi_video_current_level;
 
-/* hw.acpi.video  backlight economy level (one of video_levels)*/
+/* hw.acpi.video  backlight economy level (one of video_levels) */
 int acpi_video_economy_level = -1;
 
-/* hw.acpi.video backlight fullpower level (one of video_levels)*/
+/* hw.acpi.video backlight fullpower level (one of video_levels) */
 int acpi_video_fullpower_level = -1;
 
-/* Backlight(9) current level (one of video_levels)*/
+/* Backlight(9) current level (one of video_levels) */
 int backlight_current_level;
 
-/* Backlight(9) economy level (one of video_levels)*/
+/* Backlight(9) economy level (one of video_levels) */
 int backlight_economy_level = -1;
 
-/* Backlight(9) fullpower level level (one of video_levels)*/
+/* Backlight(9) fullpower level level (one of video_levels) */
 int backlight_fullpower_level = -1;
 
 /* set 1 if AC powered else 0 */
 int ac_powered = 0;
 
-/* set 1 if backlight(9) instead of hw.acpi.video*/
+/* set 1 if backlight(9) instead of hw.acpi.video */
 int use_backlight = 0;
 
-/* file name of default backlight device*/
+/* file name of default backlight device */
 static char *backlight_device = "/dev/backlight/backlight0";
 
 /* file name to save state */
@@ -372,7 +372,16 @@ int get_video_down_level() {
 
 	   Therefore, this function, if using backlight(9), will decrease at a
 	   minimum level of 2.
+
+	   The only way to set the backlight to truly dim is by setting
+	   backlight=0 when the backlight=1 is not previously set. The follow
+	   line assures that if backlight=2, it does not set backlight=1 but
+	   instead backlight=0.
 	*/
+
+	if (use_backlight && props.nlevels == 0 && v == 2) {
+		v--;
+	}
 
 	for (i = num_of_video_levels - 1; i >= 0; i--) {
 		if (video_levels[i] == v) {

--- a/src/asmctl.c
+++ b/src/asmctl.c
@@ -598,7 +598,7 @@ int init_capsicum() {
 		return rc;
 	}
 
-	/* limit conf_fd to read/write/seek/fcntl */
+	/* limit conf_fd to read/write/seek/fcntl/ftruncate */
 	/* fcntl is used in fdopen(3) */
 	cap_rights_init(&conf_fd_rights,
 			CAP_READ | CAP_WRITE | CAP_SEEK | CAP_FCNTL | CAP_FTRUNCATE);

--- a/src/asmctl.c
+++ b/src/asmctl.c
@@ -737,6 +737,7 @@ int main(int argc, char *argv[]) {
 					rc = -1;
 				}
 			}
+			free(video_levels);
 		}
 		if (strcmp(argv[1], "kb") == 0 || strcmp(argv[1], "kbd") == 0 ||
 		    strcmp(argv[1], "keyboard") == 0 ||

--- a/src/asmctl.c
+++ b/src/asmctl.c
@@ -601,7 +601,7 @@ int init_capsicum() {
 	/* limit conf_fd to read/write/seek/fcntl */
 	/* fcntl is used in fdopen(3) */
 	cap_rights_init(&conf_fd_rights,
-			CAP_READ | CAP_WRITE | CAP_SEEK | CAP_FCNTL);
+			CAP_READ | CAP_WRITE | CAP_SEEK | CAP_FCNTL | CAP_FTRUNCATE);
 	rc = cap_rights_limit(conf_fd, &conf_fd_rights);
 	if (rc < 0) {
 		fprintf(stderr, "cap_rights_limit() failed\n");

--- a/src/asmctl.c
+++ b/src/asmctl.c
@@ -748,7 +748,7 @@ int main(int argc, char *argv[]) {
 						: backlight_economy_level;
 				}
 				rc = set_lcd_brightness(d);
-			} else { /* human acmtl call: use current brightness */
+			} else { /* human asmctl call: use current brightness */
 				if (use_backlight == 0) {
 					/* may be -1, will fail get_video_up_level/get_video_down_level */
 					acpi_video_current_level=get_acpi_video_level();


### PR DESCRIPTION
This PR solves various issues. I have decided not to rebase the patch into a single commit due to the large amount of changes. 

These patches addresses the following issues:

1. If the acpi_video module does not work on the system, the hw.acpi.video.lcd0 sysctls will not be available. However, the backlight(9) API may still be used. This patch adds the ability to use that it the sysctl method is unavailable.
2. Rewrites much of the program to be consistently formatted. 
3. Cleans up file descriptors and memory on exit.
4. Fixes a bug where ftruncate fails because the capability was never added. This meant that the .conf file could become corrupted as it was never cleared before a write.
5. The keyboard backlight was not restored on a system reboot -- `asmctl key acpi` solves this.
6. On the first run of `asmctl`, the incorrect fullpower and economy value would be set.
7. The video levels may not always be retrieved sequentially, so a sort is necessary.